### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -29,5 +29,5 @@ FTDIEve	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-EVE_CALIBRATE    LITERAL1
-EVE_TRIM         LITERAL1
+EVE_CALIBRATE	LITERAL1
+EVE_TRIM	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords